### PR TITLE
Update jest diagnostics to warn only

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,11 @@
 module.exports = {
+    globals: {
+        "ts-jest": {
+            diagnostics: {
+                warnOnly: true
+            }
+        }
+    },
     transform: {
         ".ts": "ts-jest"
     },
@@ -34,5 +41,5 @@ module.exports = {
     collectCoverageFrom: [
         "src/**/*.{js,ts}",
         "!**/node_modules/**"
-    ]
+    ]    
 }


### PR DESCRIPTION
Fixes errors such as the following:
```console
ts-jest[ts-compiler] (WARN) TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
tests/breeze-odata4-dataService.spec.ts:120:13 - error TS2740: Type '{}' is missing the following properties from type 'Window': Blob, TextDecoder, TextEncoder, URL, and 234 more.
```