### PR TITLE
fix(query): fixes entity query with object argument

### DIFF
--- a/src/breeze-odata4-entity-query.ts
+++ b/src/breeze-odata4-entity-query.ts
@@ -27,7 +27,7 @@ export class OData4EntityQuery extends EntityQuery {
         }
 
         // save the subquery for later
-        this.parameters[ExpandParamsKey] = this.parameters[ExpandParamsKey] || {};
+        this.parameters[ExpandParamsKey] ??= {};
         this.parameters[ExpandParamsKey][propertyPaths] = subQuery;
 
         return this;

--- a/src/breeze-odata4-uriBuilder.ts
+++ b/src/breeze-odata4-uriBuilder.ts
@@ -102,7 +102,7 @@ export class OData4UriBuilder implements UriBuilderAdapter {
 
     this.addSelectOption(entityType, queryOptions, entityQuery.selectClause);
 
-    if (entityQuery.parameters[ExpandParamsKey]) {
+    if (entityQuery.parameters && entityQuery.parameters[ExpandParamsKey]) {
       this.addExpandOptionsFromSubqueries(entityType, queryOptions, entityQuery.parameters[ExpandParamsKey]);
       delete entityQuery.parameters[ExpandParamsKey];
     }

--- a/tests/breeze-odata4-uriBuilder.spec.ts
+++ b/tests/breeze-odata4-uriBuilder.spec.ts
@@ -98,6 +98,15 @@ describe('OData4UriBuilder', () => {
             expect(result).toEqual(`${query.resourceName}?$filter=firstName%20eq%20'Test'`);
         });
 
+        it('should allow using entity query object', () => {
+            const navProperty = 'id';
+            query = new EntityQuery({from: 'Person', expand: [navProperty]});
+
+            const result = sut.buildUri(query, metadataStore);
+
+            expect(result).toEqual(`${query.resourceName}?$expand=${navProperty}`);
+        });
+
         it('should add multiple filter options', () => {
             const predicate = new Predicate('firstName', 'eq', 'Test');
             query = query.where(predicate).where('personId', 'eq', 1);


### PR DESCRIPTION
EntityQuery execution was failing when parameters are not defined. Updated to check if parameters
exist first.