### PR TITLE
fix(dataservice): fixes entity updates using json ajax adapter

### DIFF
--- a/src/ajax-adapters/breeze-odata4-ajax-adapter.ts
+++ b/src/ajax-adapters/breeze-odata4-ajax-adapter.ts
@@ -5,6 +5,10 @@ import { Batch, Edmx } from 'ts-odatajs';
 import { DataServiceSaveContext } from '../breeze-odata4-dataService-adapter';
 import { ODataHttpClient } from '../odata-http-client';
 
+const ContentIdHeader = 'Content-ID';
+const ContentTypeHeader = 'Content-Type';
+const IfMatchHeader = 'If-Match';
+const ODataVersionHeader = 'OData-Version';
 
 /**
  * @classdesc OData4 ajax adapter, used for data saving in the @see OData4DataServiceAdapter
@@ -33,7 +37,7 @@ export abstract class OData4AjaxAdapter implements AjaxAdapter {
 
   public defaultSettings: { headers?: { [name: string]: string; }; } = {
     headers: {
-      'OData-Version': '4.0'
+      [ODataVersionHeader]: '4.0'
     }
   };
 
@@ -59,8 +63,8 @@ export abstract class OData4AjaxAdapter implements AjaxAdapter {
 
     const result: Batch.ChangeRequest = {
       headers: {
-        'Content-ID': contentId.toString(),
-        'Content-Type': 'application/json;IEEE754Compatible=true',
+        [ContentIdHeader]: contentId.toString(),
+        [ContentTypeHeader]: 'application/json;IEEE754Compatible=true',
         ...this.defaultSettings?.headers
       },
       requestUri: null,
@@ -104,7 +108,7 @@ export abstract class OData4AjaxAdapter implements AjaxAdapter {
 
     changeResponses.forEach(changeResponse => {
       // The server is required to provide the Content-ID header starting at 1, use 0 and effectively ignore it if not provided.
-      const contentId = Number((changeResponse.headers || {})['Content-ID'] ?? 0);
+      const contentId = Number((changeResponse.headers || {})[ContentIdHeader] ?? 0);
 
       const origEntity = contentKeys[contentId];
       const rawEntity: Entity = changeResponse.data;
@@ -160,7 +164,6 @@ export abstract class OData4AjaxAdapter implements AjaxAdapter {
    */
   protected updateDeleteMergeRequest(request: Batch.ChangeRequest, aspect: EntityAspect, routePrefix: string): void {
     const etagName = 'etag';
-    const ifMatchHeader = 'If-Match';
     const uriKeyName = 'uriKey';
 
     if (!aspect.extraMetadata) {
@@ -169,7 +172,7 @@ export abstract class OData4AjaxAdapter implements AjaxAdapter {
 
     const extraMetadata = aspect.extraMetadata;
     if (extraMetadata[etagName]) {
-      request.headers[ifMatchHeader] = extraMetadata[etagName];
+      request.headers[IfMatchHeader] = extraMetadata[etagName];
     }
 
     if (!extraMetadata[uriKeyName]) {

--- a/src/breeze-odata4-dataService-adapter.ts
+++ b/src/breeze-odata4-dataService-adapter.ts
@@ -132,7 +132,6 @@ export class OData4DataServiceAdapter extends AbstractDataServiceAdapter {
       return result;
     });
 
-    // TODO: Configure whether to prevent reject on failure
     if (failedResponse && this._options.failOnSaveError) {
       const err = this.createError(failedResponse, saveContext.requestUri);
       reject(err);

--- a/tests/ajax-adapters/breeze-odata4-json-ajax-adapter.spec.ts
+++ b/tests/ajax-adapters/breeze-odata4-json-ajax-adapter.spec.ts
@@ -127,7 +127,7 @@ describe('OData4JsonAjaxAdapter', () => {
                 expect(result.__batchResponses[0].__changeResponses).toHaveLength(0);
             });
 
-            it('with one change request should return on change response', async () => {
+            it('with one change request should return one change response', async () => {
                 changeRequests.push({
                     headers: {
                         'Content-ID': '1',
@@ -175,6 +175,25 @@ describe('OData4JsonAjaxAdapter', () => {
                 const result = response.data as Batch.BatchResponse;
                 expect(result.__batchResponses).toHaveLength(1);
                 expect(result.__batchResponses[0].__changeResponses).toHaveLength(2);
+            });
+
+            it('with change request should set Content-ID on change response', async () => {
+                changeRequests.push({
+                    headers: {
+                        'Content-ID': '1',
+                        'Content-Type': 'application/json'
+                    },
+                    requestUri: 'https://localhost/testing/Person',
+                    method: 'POST',
+                    data: { id: 1, firstName: 'Test' }
+                });
+                const response = await new Promise<HttpResponse>((resolve) => {
+                    ajaxConfig.success = res => resolve(res);
+                    sut.ajax(ajaxConfig, httpClient, metadata);
+                });
+
+                const result = response.data as Batch.BatchResponse;
+                expect((result.__batchResponses[0].__changeResponses[0] as Batch.ChangeResponse).headers['Content-ID']).toEqual(changeRequests[0].headers['Content-ID']);
             });
 
             it('should return failed responses', async () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    //"baseUrl": ".",
+    "baseUrl": ".",
     "declaration": true,
     "declarationDir": "dist/types",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Preserves the Content-ID header passed in the change request so that it can be correlated back to
the entity when resolving the save result.