### PR TITLE
fix(adapter): updates to use headers in json ajax adapter

### DIFF
--- a/src/ajax-adapters/breeze-odata4-json-ajax-adapter.ts
+++ b/src/ajax-adapters/breeze-odata4-json-ajax-adapter.ts
@@ -34,12 +34,14 @@ export class OData4JsonAjaxAdapter extends OData4AjaxAdapter {
 
     const promises = changeRequests.map(cr => {
       const result = new Promise<Batch.ChangeResponse>((resolve, reject) => {
+        const headers = { ...ajaxConfig.headers, ...cr.headers };
+
         // preserve the Content-ID header
-        const contentId = cr.headers[ContentIdHeader];
+        const contentId = headers[ContentIdHeader];
         const request: HttpOData.Request = {
           method: cr.method,
           requestUri: cr.requestUri,
-          headers: cr.headers,
+          headers,
           data: cr.data
         };
 


### PR DESCRIPTION
The configured headers were not being used in ajax calls when using the json ajax adapter. This
fixes the logic to pass along the headers.