### PR TITLE
feat(navigation-adapter): adds convention for partial matching key property

### DIFF
--- a/src/options/navigation-adapter-options.ts
+++ b/src/options/navigation-adapter-options.ts
@@ -9,11 +9,26 @@ export const DefaultNavigationAdapterOptions: NavigationAdapterOptions = {
     (endpoint, suffix) => `${endpoint.propertyName}${suffix}`.toLowerCase(),
     (endpoint) => `${endpoint.propertyName}Id`.toLowerCase(),
     (endpoint, suffix) => `${endpoint.partnerEntityShortName}${suffix}`.toLowerCase(),
-    (endpoint) => `${endpoint.partnerEntityShortName}Id`.toLowerCase()
+    (endpoint) => `${endpoint.partnerEntityShortName}Id`.toLowerCase(),
+    getPartialMatchingProperty,
+    (endpoint) => getPartialMatchingProperty(endpoint, 'id')
   ],
   inferNavigationPropertyPartner: true,
   inferReferentialConstraints: true
 };
+
+function getPartialMatchingProperty(endpoint: AssociationEndpoint, suffix: string): string {
+  const propertyName = endpoint.propertyName.toLowerCase();
+  const partnerEntityName = endpoint.partnerEntityShortName.toLowerCase();
+  const propertyEnd = propertyName.replace(partnerEntityName, '');
+  if (!propertyEnd || propertyEnd === suffix) {
+    return null;
+  }
+
+  const result = `${propertyEnd}${suffix}`.toLowerCase();
+
+  return result;
+}
 
 /**
  * The navigation adapter options.

--- a/tests/adapters/navigation-adapter.spec.ts
+++ b/tests/adapters/navigation-adapter.spec.ts
@@ -284,6 +284,17 @@ describe('NavigationAdapter', () => {
     expect(schema.association).toHaveLength(0);
   });
 
+  it('should add associations for partial matching navigation property', () => {
+    const entityType = getProductEntityType();
+    entityType.property?.push({name: 'ParentId', type: 'Edm.Int32'});
+    entityType.navigationProperty = [{ name: 'ParentProduct', type: 'UnitTesting.Product' }];
+    schema.entityType = [entityType];
+
+    sut.adapt(metadata.dataServices);
+
+    expect(schema.association[0].referentialConstraint.dependent.propertyRef[0]).toMatchObject({name: 'ParentId'});
+  });
+
   it('should throw Error when adapt is called with missing entityType', () => {
     const entityType = getProductEntityType();
     entityType.navigationProperty = [{ name: 'NotHere', type: 'UnitTesting.Nothing' }];


### PR DESCRIPTION
Built-in foreign key convention for doing a partial match on the navigation property name