### PR TITLE
Fix encode semicolon in URI

### DIFF
--- a/src/breeze-odata4-uriBuilder.ts
+++ b/src/breeze-odata4-uriBuilder.ts
@@ -280,7 +280,7 @@ export class OData4UriBuilder implements UriBuilder {
         return option.name;
       }
 
-      return `${option.name}(${subOptions.join(';')})`;
+      return `${option.name}(${subOptions.join(encodeURIComponent(';'))})`;
     });
 
     const result = expandStrings.length ? `${key}=${expandStrings}` : null;


### PR DESCRIPTION
Hi @tschettler ,
we are having problems with the semicolon `;` in the ODATA4 request URL. Different environments interpret it in differently: sometimes it is replaced by an ampersand `&` (eg. from Windows or Linux shells). Encoding it fixes the unpredictable result. I used the original `buildUri` as inspiration.  https://github.com/Breeze/breeze-client/blob/83264900b6396b1c6530b96c0bb94e3e527252a1/src/adapter-uri-builder-json.ts#L33C21-L33C39 

Thanks.